### PR TITLE
Fix IndexOutOfRangeException in SBCSGroupProber.DumpStatus.

### DIFF
--- a/src/Library/Ude.Core/SBCSGroupProber.cs
+++ b/src/Library/Ude.Core/SBCSGroupProber.cs
@@ -147,7 +147,10 @@ namespace Ude.Core
                 else
                     sb.AppendLine(probers[i].DumpStatus());
             }
-            sb.Append($"SBCS Group found best match [{probers[bestGuess].GetCharsetName()}] confidence {cf}.");
+
+            var bestMatch = bestGuess >= 0 ? probers[bestGuess].GetCharsetName() : null;
+
+            sb.Append($"SBCS Group found best match [{bestMatch}] confidence {cf}.");
 
             return sb.ToString();
         }


### PR DESCRIPTION
This was possible when variable bestGuess == -1.